### PR TITLE
added a refresh method to branch service

### DIFF
--- a/src/main/java/com/nerdwin15/bacabs/service/WildflyRemoteDeploymentRetriever.java
+++ b/src/main/java/com/nerdwin15/bacabs/service/WildflyRemoteDeploymentRetriever.java
@@ -98,6 +98,8 @@ public class WildflyRemoteDeploymentRetriever implements RemoteDeploymentRetriev
     request.get(OP_ADDR).add(DEPLOYMENT);
 
     ModelNode returnVal = wildflyClient.execute(request);
+    gitBranchRetrievalService.refresh();
+
     for (Property property : returnVal.get(RESULT).get(DEPLOYMENT).asPropertyList()) {
       String href = getHref(property.getName());
       if (href == null || href.isEmpty())

--- a/src/main/java/com/nerdwin15/bacabs/service/git/GitBranchRetrievalService.java
+++ b/src/main/java/com/nerdwin15/bacabs/service/git/GitBranchRetrievalService.java
@@ -21,16 +21,24 @@ package com.nerdwin15.bacabs.service.git;
 import com.nerdwin15.bacabs.GitBranch;
 
 /**
- * A service that is used to retrieve a branch from a Gitlab
- * REST endpoint.
+ * A service that is used to retrieve a branches from a Git
+ * repository.
  *
  * @author Chris Dunavant
+ * @author Carl Harris
  */
 public interface GitBranchRetrievalService {
 
   /**
-   * Retrieve the information for a given Gitlab branch
-   * @param branch The authenticated REST url
+   * Refreshes the repository (e.g. by invoking fetch to retrieve commits
+   * from a remote repository).
+   */
+  void refresh();
+
+  /**
+   * Retrieve the information for a given Git branch
+   * @param branch the subject branch
    */
   GitBranch retrieveGitBranch(String branch);
+
 }

--- a/src/main/java/com/nerdwin15/bacabs/service/git/LocalGitBranchRetrievalServiceBean.java
+++ b/src/main/java/com/nerdwin15/bacabs/service/git/LocalGitBranchRetrievalServiceBean.java
@@ -85,10 +85,20 @@ public class LocalGitBranchRetrievalServiceBean
   }
 
   @Override
+  public void refresh() {
+    try {
+      fetch(directory, REMOTE);
+    }
+    catch (GitAPIException | IOException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  @Override
   public GitBranch retrieveGitBranch(String branch) {
     String refName = String.format(REMOTE_BRANCH_FORMAT, REMOTE, branch);
     try {
-      Git git = fetch(directory, REMOTE);
+      Git git = newGit(directory);
       List<Ref> branches = git.branchList()
           .setListMode(ListBranchCommand.ListMode.REMOTE)
           .call();

--- a/src/main/java/com/nerdwin15/bacabs/service/git/RestGitBranchRetrievalServiceBean.java
+++ b/src/main/java/com/nerdwin15/bacabs/service/git/RestGitBranchRetrievalServiceBean.java
@@ -45,7 +45,11 @@ public class RestGitBranchRetrievalServiceBean
   
   @Inject @GitClient
   protected Client client;
-  
+
+  @Override
+  public void refresh() {
+  }
+
   /**
    * {@inheritDoc}
    */


### PR DESCRIPTION
By calling this once at the start of a sync cycle, we avoid
doing a fetch on the remote repo for each branch retrieval.